### PR TITLE
refactor: make H2 bridge content-type and protocol headers configurable

### DIFF
--- a/src/h2-bridge.mjs
+++ b/src/h2-bridge.mjs
@@ -80,7 +80,7 @@ const configBuf = await readMessage();
 if (!configBuf) process.exit(1);
 
 const config = JSON.parse(configBuf.toString("utf8"));
-const { accessToken, url, path: rpcPath } = config;
+const { accessToken, url, path: rpcPath, contentType, connectProtocolVersion } = config;
 
 const client = http2.connect(url || "https://api2.cursor.sh");
 
@@ -104,18 +104,22 @@ client.on("error", () => {
   process.exit(1);
 });
 
-const h2Stream = client.request({
+const headers = {
   ":method": "POST",
   ":path": rpcPath || "/agent.v1.AgentService/Run",
-  "content-type": "application/connect+proto",
-  "connect-protocol-version": "1",
+  "content-type": contentType || "application/connect+proto",
   te: "trailers",
   authorization: `Bearer ${accessToken}`,
   "x-ghost-mode": "true",
   "x-cursor-client-version": CURSOR_CLIENT_VERSION,
   "x-cursor-client-type": "cli",
   "x-request-id": crypto.randomUUID(),
-});
+};
+if (connectProtocolVersion) {
+  headers["connect-protocol-version"] = connectProtocolVersion;
+}
+
+const h2Stream = client.request(headers);
 
 // Forward H2 response data → stdout (length-prefixed)
 h2Stream.on("data", (chunk) => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -191,6 +191,8 @@ interface SpawnBridgeOptions {
   accessToken: string;
   rpcPath: string;
   url?: string;
+  contentType?: string;
+  connectProtocolVersion?: string;
 }
 
 function spawnBridge(options: SpawnBridgeOptions): {
@@ -212,6 +214,8 @@ function spawnBridge(options: SpawnBridgeOptions): {
     accessToken: options.accessToken,
     url: options.url ?? CURSOR_API_URL,
     path: options.rpcPath,
+    contentType: options.contentType,
+    connectProtocolVersion: options.connectProtocolVersion,
   });
   proc.stdin.write(lpEncode(new TextEncoder().encode(config)));
 
@@ -282,6 +286,8 @@ interface CursorUnaryRpcOptions {
   requestBody: Uint8Array;
   url?: string;
   timeoutMs?: number;
+  contentType?: string;
+  connectProtocolVersion?: string;
 }
 
 export async function callCursorUnaryRpc(
@@ -291,6 +297,8 @@ export async function callCursorUnaryRpc(
     accessToken: options.accessToken,
     rpcPath: options.rpcPath,
     url: options.url,
+    contentType: options.contentType ?? "application/grpc+proto",
+    connectProtocolVersion: options.connectProtocolVersion,
   });
   const chunks: Buffer[] = [];
   const { promise, resolve } = Promise.withResolvers<{
@@ -1263,6 +1271,8 @@ function startBridge(
   const bridge = spawnBridge({
     accessToken,
     rpcPath: "/agent.v1.AgentService/Run",
+    contentType: "application/connect+proto",
+    connectProtocolVersion: "1",
   });
   bridge.write(frameConnectMessage(requestBytes));
   const heartbeatTimer = setInterval(() => bridge.write(makeHeartbeatBytes()), 5_000);


### PR DESCRIPTION
- Makes content-type and connect-protocol-version HTTP/2 headers configurable in the bridge instead of hardcoding them
- Streaming RPCs (startBridge) explicitly pass application/connect+proto with connect-protocol-version: 1
- Unary RPCs (callCursorUnaryRpc) default to application/grpc+proto without the connect-protocol-version header

The bridge previously hardcoded content-type: application/connect+proto and connect-protocol-version: 1 for all requests. However, unary RPCs use gRPC framing (application/grpc+proto) and should not include the connect protocol version header. This change lets each caller specify the correct headers for its protocol.

This makes the model discovery work correctly 

<img width="635" height="494" alt="image" src="https://github.com/user-attachments/assets/af921c4f-8d30-46f0-913d-673dc676ca2a" />

<img width="635" height="494" alt="image" src="https://github.com/user-attachments/assets/5df15ef4-0643-4adc-b562-ffe3772d9bc7" />
