### PR TITLE
fix: wrap loader in try/catch to prevent cascading plugin failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,81 +29,109 @@ export const CursorAuthPlugin: Plugin = async (
       provider: CURSOR_PROVIDER_ID,
 
       async loader(getAuth, provider) {
-        const auth = await getAuth();
-        if (!auth || auth.type !== "oauth") return {};
+        try {
+          const auth = await getAuth();
+          if (!auth || auth.type !== "oauth") return {};
 
-        // Ensure we have a valid access token, refreshing if expired
-        let accessToken = auth.access;
-        if (!accessToken || auth.expires < Date.now()) {
-          const refreshed = await refreshCursorToken(auth.refresh);
-          await input.client.auth.set({
-            path: { id: CURSOR_PROVIDER_ID },
-            body: {
-              type: "oauth",
-              refresh: refreshed.refresh,
-              access: refreshed.access,
-              expires: refreshed.expires,
-            },
-          });
-          accessToken = refreshed.access;
-        }
-
-        const models = await getCursorModels(accessToken);
-
-        const port = await startProxy(async () => {
-          const currentAuth = await getAuth();
-          if (currentAuth.type !== "oauth") {
-            throw new Error("Cursor auth not configured");
-          }
-
-          if (!currentAuth.access || currentAuth.expires < Date.now()) {
-            const refreshed = await refreshCursorToken(currentAuth.refresh);
-            await input.client.auth.set({
-              path: { id: CURSOR_PROVIDER_ID },
-              body: {
-                type: "oauth",
-                refresh: refreshed.refresh,
-                access: refreshed.access,
-                expires: refreshed.expires,
-              },
-            });
-            return refreshed.access;
-          }
-
-          return currentAuth.access;
-        }, models);
-
-        if (provider) {
-          (provider as any).models = buildCursorProviderModels(models, port);
-        }
-
-        return {
-          baseURL: `http://localhost:${port}/v1`,
-          apiKey: "cursor-proxy",
-          async fetch(
-            requestInput: RequestInfo | URL,
-            init?: RequestInit,
-          ) {
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                init.headers.delete("authorization");
-              } else if (Array.isArray(init.headers)) {
-                init.headers = init.headers.filter(
-                  ([key]) => key.toLowerCase() !== "authorization",
-                );
-              } else {
-                delete (init.headers as Record<string, string>)[
-                  "authorization"
-                ];
-                delete (init.headers as Record<string, string>)[
-                  "Authorization"
-                ];
-              }
+          // Ensure we have a valid access token, refreshing if expired
+          let accessToken = auth.access;
+          if (!accessToken || auth.expires < Date.now()) {
+            if (!auth.refresh) {
+              console.error("[cursor-oauth] No refresh token available — re-authenticate with: opencode auth login --provider cursor");
+              return {};
             }
+            try {
+              const refreshed = await refreshCursorToken(auth.refresh);
+              await input.client.auth.set({
+                path: { id: CURSOR_PROVIDER_ID },
+                body: {
+                  type: "oauth",
+                  refresh: refreshed.refresh,
+                  access: refreshed.access,
+                  expires: refreshed.expires,
+                },
+              });
+              accessToken = refreshed.access;
+            } catch (refreshErr) {
+              console.error(`[cursor-oauth] Token refresh failed: ${refreshErr instanceof Error ? refreshErr.message : refreshErr}`);
+              console.error("[cursor-oauth] Re-authenticate with: opencode auth login --provider cursor");
+              return {};
+            }
+          }
 
-            return fetch(requestInput, init);
-          },
-        };
+          let models: CursorModel[];
+          try {
+            models = await getCursorModels(accessToken);
+          } catch (modelErr) {
+            console.error(`[cursor-oauth] Model discovery failed, using fallback models: ${modelErr instanceof Error ? modelErr.message : modelErr}`);
+            models = await getCursorModels(accessToken); // getCursorModels already has internal fallback
+          }
+
+          let port: number;
+          try {
+            port = await startProxy(async () => {
+              const currentAuth = await getAuth();
+              if (currentAuth.type !== "oauth") {
+                throw new Error("Cursor auth not configured");
+              }
+
+              if (!currentAuth.access || currentAuth.expires < Date.now()) {
+                const refreshed = await refreshCursorToken(currentAuth.refresh);
+                await input.client.auth.set({
+                  path: { id: CURSOR_PROVIDER_ID },
+                  body: {
+                    type: "oauth",
+                    refresh: refreshed.refresh,
+                    access: refreshed.access,
+                    expires: refreshed.expires,
+                  },
+                });
+                return refreshed.access;
+              }
+
+              return currentAuth.access;
+            }, models);
+          } catch (proxyErr) {
+            console.error(`[cursor-oauth] Proxy failed to start: ${proxyErr instanceof Error ? proxyErr.message : proxyErr}`);
+            return {};
+          }
+
+          if (provider) {
+            (provider as any).models = buildCursorProviderModels(models, port);
+          }
+
+          return {
+            baseURL: `http://localhost:${port}/v1`,
+            apiKey: "cursor-proxy",
+            async fetch(
+              requestInput: RequestInfo | URL,
+              init?: RequestInit,
+            ) {
+              if (init?.headers) {
+                if (init.headers instanceof Headers) {
+                  init.headers.delete("authorization");
+                } else if (Array.isArray(init.headers)) {
+                  init.headers = init.headers.filter(
+                    ([key]) => key.toLowerCase() !== "authorization",
+                  );
+                } else {
+                  delete (init.headers as Record<string, string>)[
+                    "authorization"
+                  ];
+                  delete (init.headers as Record<string, string>)[
+                    "Authorization"
+                  ];
+                }
+              }
+
+              return fetch(requestInput, init);
+            },
+          };
+        } catch (err) {
+          // Catch-all: never let loader errors propagate and kill other plugins
+          console.error(`[cursor-oauth] Loader failed: ${err instanceof Error ? err.message : err}`);
+          return {};
+        }
       },
 
       methods: [


### PR DESCRIPTION
## Problem

When the loader function throws (from `refreshCursorToken`, `getCursorModels`, or `startProxy`), the unhandled exception propagates up to OpenCode's plugin system and **silently kills all plugin loading** — including unrelated plugins in the same `plugin` array.

This means a Cursor auth failure (expired token, network error, proxy port conflict) breaks the entire plugin ecosystem with no error message visible to the user.

## Fix

- Wrap the entire loader in a top-level try/catch that returns `{}` on any failure
- Add specific try/catch blocks for token refresh, model discovery, and proxy startup — each with actionable error messages
- Check for missing refresh token before attempting refresh
- Log `[cursor-oauth]` prefixed messages to stderr so users can diagnose issues

## What this does NOT fix

OpenCode v1.2.27 has a separate bug where any plugin returning `auth` with a `methods` array crashes the TUI worker with `Expected string, got undefined` (tracked at anomalyco/opencode#18536). That crash happens during Zod schema validation before the loader even runs — this PR can't fix it. But once OpenCode fixes their auth hook handling, this error handling will prevent loader failures from cascading.

## Testing

- Built with `bun run build` — compiles cleanly
- Verified that with the fix, a failed token refresh logs an error and returns `{}` instead of throwing