### PR TITLE
fix: model discovery, fallback IDs, and conversation context persistence

### DIFF
--- a/src/h2-bridge.mjs
+++ b/src/h2-bridge.mjs
@@ -10,8 +10,11 @@
  *   [4 bytes big-endian length][payload]
  *
  * First message on stdin is JSON config:
- *   { "accessToken": "...", "url": "...", "path": "..." }
+ *   { "accessToken": "...", "url": "...", "path": "...", "unary": false }
  *
+ * When unary=true, the bridge uses application/proto (raw protobuf) instead
+ * of application/connect+proto (Connect streaming). The single stdin message
+ * is written as the request body and the stream is ended immediately.
  * After config, subsequent stdin messages are raw bytes to write to the H2 stream.
  * H2 response data is written to stdout using the same length-prefixed framing.
  */
@@ -80,7 +83,7 @@ const configBuf = await readMessage();
 if (!configBuf) process.exit(1);
 
 const config = JSON.parse(configBuf.toString("utf8"));
-const { accessToken, url, path: rpcPath } = config;
+const { accessToken, url, path: rpcPath, unary } = config;
 
 const client = http2.connect(url || "https://api2.cursor.sh");
 
@@ -104,18 +107,21 @@ client.on("error", () => {
   process.exit(1);
 });
 
-const h2Stream = client.request({
+const headers = {
   ":method": "POST",
   ":path": rpcPath || "/agent.v1.AgentService/Run",
-  "content-type": "application/connect+proto",
-  "connect-protocol-version": "1",
+  "content-type": unary ? "application/proto" : "application/connect+proto",
   te: "trailers",
   authorization: `Bearer ${accessToken}`,
   "x-ghost-mode": "true",
   "x-cursor-client-version": CURSOR_CLIENT_VERSION,
   "x-cursor-client-type": "cli",
   "x-request-id": crypto.randomUUID(),
-});
+};
+if (!unary) {
+  headers["connect-protocol-version"] = "1";
+}
+const h2Stream = client.request(headers);
 
 // Forward H2 response data → stdout (length-prefixed)
 h2Stream.on("data", (chunk) => {
@@ -137,20 +143,31 @@ h2Stream.on("error", () => {
 });
 
 // Forward stdin → H2 stream (after config message)
-(async () => {
-  while (true) {
-    const msg = await readMessage();
-    if (!msg || msg.length === 0) {
-      // EOF or zero-length = done writing
-      break;
-    }
-    if (!h2Stream.closed && !h2Stream.destroyed) {
-      resetTimeout();
-      h2Stream.write(msg);
-    }
-  }
-
-  if (!h2Stream.closed && !h2Stream.destroyed) {
+if (unary) {
+  // Unary mode: read a single body message, write it, and end the stream.
+  const body = await readMessage();
+  if (body && body.length > 0 && !h2Stream.closed && !h2Stream.destroyed) {
+    h2Stream.end(body);
+  } else {
     h2Stream.end();
   }
-})();
+} else {
+  // Streaming mode: forward all stdin messages as Connect frames.
+  (async () => {
+    while (true) {
+      const msg = await readMessage();
+      if (!msg || msg.length === 0) {
+        // EOF or zero-length = done writing
+        break;
+      }
+      if (!h2Stream.closed && !h2Stream.destroyed) {
+        resetTimeout();
+        h2Stream.write(msg);
+      }
+    }
+
+    if (!h2Stream.closed && !h2Stream.destroyed) {
+      h2Stream.end();
+    }
+  })();
+}

--- a/src/models.ts
+++ b/src/models.ts
@@ -44,18 +44,22 @@ export interface CursorModel {
 }
 
 const FALLBACK_MODELS: CursorModel[] = [
-  { id: "composer-2", name: "Composer 2", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
-  { id: "composer-2-fast", name: "Composer 2 Fast", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
-  { id: "claude-4.6-opus", name: "Claude 4.6 Opus", reasoning: true, contextWindow: 200_000, maxTokens: 128_000 },
-  { id: "claude-4.6-sonnet", name: "Claude 4.6 Sonnet", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
+  // Composer models
+  { id: "composer-1", name: "Composer 1", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
+  { id: "composer-1.5", name: "Composer 1.5", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
+  // Claude models
+  { id: "claude-4.6-opus-high", name: "Claude 4.6 Opus", reasoning: true, contextWindow: 200_000, maxTokens: 128_000 },
+  { id: "claude-4.6-sonnet-medium", name: "Claude 4.6 Sonnet", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
   { id: "claude-4.5-sonnet", name: "Claude 4.5 Sonnet", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
-  { id: "claude-4-sonnet", name: "Claude 4 Sonnet", reasoning: true, contextWindow: 200_000, maxTokens: 64_000 },
-  { id: "gpt-5.4", name: "GPT-5.4", reasoning: true, contextWindow: 272_000, maxTokens: 128_000 },
+  // GPT models
+  { id: "gpt-5.4-medium", name: "GPT-5.4", reasoning: true, contextWindow: 272_000, maxTokens: 128_000 },
   { id: "gpt-5.2", name: "GPT-5.2", reasoning: true, contextWindow: 400_000, maxTokens: 128_000 },
+  { id: "gpt-5.2-codex", name: "GPT-5.2 Codex", reasoning: true, contextWindow: 400_000, maxTokens: 128_000 },
   { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", reasoning: true, contextWindow: 400_000, maxTokens: 128_000 },
-  { id: "gpt-5.3-codex-spark", name: "GPT-5.3 Codex Spark", reasoning: true, contextWindow: 128_000, maxTokens: 128_000 },
+  { id: "gpt-5.3-codex-spark-preview", name: "GPT-5.3 Codex Spark", reasoning: true, contextWindow: 128_000, maxTokens: 128_000 },
+  // Other models
   { id: "gemini-3.1-pro", name: "Gemini 3.1 Pro", reasoning: true, contextWindow: 1_000_000, maxTokens: 64_000 },
-  { id: "grok-4.20", name: "Grok 4.20", reasoning: false, contextWindow: 128_000, maxTokens: 64_000 },
+  { id: "grok-code-fast-1", name: "Grok Code Fast 1", reasoning: false, contextWindow: 128_000, maxTokens: 64_000 },
 ];
 
 async function fetchCursorUsableModels(

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -191,6 +191,8 @@ interface SpawnBridgeOptions {
   accessToken: string;
   rpcPath: string;
   url?: string;
+  /** When true, use application/proto for unary RPCs instead of Connect streaming. */
+  unary?: boolean;
 }
 
 function spawnBridge(options: SpawnBridgeOptions): {
@@ -212,6 +214,7 @@ function spawnBridge(options: SpawnBridgeOptions): {
     accessToken: options.accessToken,
     url: options.url ?? CURSOR_API_URL,
     path: options.rpcPath,
+    unary: options.unary ?? false,
   });
   proc.stdin.write(lpEncode(new TextEncoder().encode(config)));
 
@@ -291,6 +294,7 @@ export async function callCursorUnaryRpc(
     accessToken: options.accessToken,
     rpcPath: options.rpcPath,
     url: options.url,
+    unary: true,
   });
   const chunks: Buffer[] = [];
   const { promise, resolve } = Promise.withResolvers<{
@@ -319,7 +323,8 @@ export async function callCursorUnaryRpc(
     });
   });
 
-  bridge.write(frameConnectMessage(options.requestBody));
+  // Unary: send raw protobuf body (no Connect framing)
+  bridge.write(options.requestBody);
   bridge.end();
 
   return promise;
@@ -440,8 +445,10 @@ function handleChatCompletion(
     );
   }
 
-  // Check for an active bridge waiting for tool results
+  // bridgeKey: model-specific, for active tool-call bridges
+  // convKey: model-independent, for conversation state that survives model switches
   const bridgeKey = deriveBridgeKey(modelId, body.messages);
+  const convKey = deriveConversationKey(body.messages);
   const activeBridge = activeBridges.get(bridgeKey);
 
   if (activeBridge && toolResults.length > 0) {
@@ -449,7 +456,7 @@ function handleChatCompletion(
 
     if (activeBridge.bridge.alive) {
       // Resume the live bridge with tool results
-      return handleToolResultResume(activeBridge, toolResults, modelId, bridgeKey);
+      return handleToolResultResume(activeBridge, toolResults, modelId, bridgeKey, convKey);
     }
 
     // Bridge died (timeout, server disconnect, etc.).
@@ -465,15 +472,15 @@ function handleChatCompletion(
     activeBridges.delete(bridgeKey);
   }
 
-  let stored = conversationStates.get(bridgeKey);
+  let stored = conversationStates.get(convKey);
   if (!stored) {
     stored = {
-      conversationId: crypto.randomUUID(),
+      conversationId: deterministicConversationId(convKey),
       checkpoint: null,
       blobStore: new Map(),
       lastAccessMs: Date.now(),
     };
-    conversationStates.set(bridgeKey, stored);
+    conversationStates.set(convKey, stored);
   }
   stored.lastAccessMs = Date.now();
   evictStaleConversations();
@@ -491,9 +498,9 @@ function handleChatCompletion(
   payload.mcpTools = mcpTools;
 
   if (body.stream === false) {
-    return handleNonStreamingResponse(payload, accessToken, modelId, bridgeKey);
+    return handleNonStreamingResponse(payload, accessToken, modelId, convKey);
   }
-  return handleStreamingResponse(payload, accessToken, modelId, bridgeKey);
+  return handleStreamingResponse(payload, accessToken, modelId, bridgeKey, convKey);
 }
 
 interface ToolResultInfo {
@@ -1085,15 +1092,41 @@ function sendExecResult(
   sendFrame(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
 }
 
-/** Derive a stable key to associate a bridge with a conversation. */
+/** Derive a key for active bridge lookup (tool-call continuations). Model-specific. */
 function deriveBridgeKey(modelId: string, messages: OpenAIMessage[]): string {
-  // Stable key from model + first user message text.
   const firstUserMsg = messages.find((m) => m.role === "user");
   const firstUserText = firstUserMsg ? textContent(firstUserMsg.content) : "";
   return createHash("sha256")
-    .update(`${modelId}:${firstUserText.slice(0, 200)}`)
+    .update(`bridge:${modelId}:${firstUserText.slice(0, 200)}`)
     .digest("hex")
     .slice(0, 16);
+}
+
+/** Derive a key for conversation state. Model-independent so context survives model switches. */
+function deriveConversationKey(messages: OpenAIMessage[]): string {
+  const firstUserMsg = messages.find((m) => m.role === "user");
+  const firstUserText = firstUserMsg ? textContent(firstUserMsg.content) : "";
+  return createHash("sha256")
+    .update(`conv:${firstUserText.slice(0, 200)}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Deterministic UUID derived from convKey so Cursor's server-side conversation
+ *  persists across proxy restarts. Formats 16 bytes of SHA-256 as a v4-shaped UUID. */
+function deterministicConversationId(convKey: string): string {
+  const hex = createHash("sha256")
+    .update(`cursor-conv-id:${convKey}`)
+    .digest("hex")
+    .slice(0, 32);
+  // Format as UUID: xxxxxxxx-xxxx-4xxx-Nxxx-xxxxxxxxxxxx
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    `4${hex.slice(13, 16)}`,
+    `${(0x8 | (parseInt(hex[16], 16) & 0x3)).toString(16)}${hex.slice(17, 20)}`,
+    hex.slice(20, 32),
+  ].join("-");
 }
 
 /** Create an SSE streaming Response that reads from a live bridge. */
@@ -1104,6 +1137,7 @@ function createBridgeStreamResponse(
   mcpTools: McpToolDefinition[],
   modelId: string,
   bridgeKey: string,
+  convKey: string,
 ): Response {
   const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
   const created = Math.floor(Date.now() / 1000);
@@ -1203,7 +1237,7 @@ function createBridgeStreamResponse(
                 closeController();
               },
               (checkpointBytes) => {
-                const stored = conversationStates.get(bridgeKey);
+                const stored = conversationStates.get(convKey);
                 if (stored) {
                   stored.checkpoint = checkpointBytes;
                   stored.lastAccessMs = Date.now();
@@ -1226,7 +1260,7 @@ function createBridgeStreamResponse(
 
       bridge.onClose((code) => {
         clearInterval(heartbeatTimer);
-        const stored = conversationStates.get(bridgeKey);
+        const stored = conversationStates.get(convKey);
         if (stored) {
           for (const [k, v] of blobStore) stored.blobStore.set(k, v);
           stored.lastAccessMs = Date.now();
@@ -1274,12 +1308,13 @@ function handleStreamingResponse(
   accessToken: string,
   modelId: string,
   bridgeKey: string,
+  convKey: string,
 ): Response {
   const { bridge, heartbeatTimer } = startBridge(accessToken, payload.requestBytes);
   return createBridgeStreamResponse(
     bridge, heartbeatTimer,
     payload.blobStore, payload.mcpTools,
-    modelId, bridgeKey,
+    modelId, bridgeKey, convKey,
   );
 }
 
@@ -1289,6 +1324,7 @@ function handleToolResultResume(
   toolResults: ToolResultInfo[],
   modelId: string,
   bridgeKey: string,
+  convKey: string,
 ): Response {
   const { bridge, heartbeatTimer, blobStore, mcpTools, pendingExecs } = active;
 
@@ -1342,7 +1378,7 @@ function handleToolResultResume(
   return createBridgeStreamResponse(
     bridge, heartbeatTimer,
     blobStore, mcpTools,
-    modelId, bridgeKey,
+    modelId, bridgeKey, convKey,
   );
 }
 
@@ -1350,11 +1386,11 @@ async function handleNonStreamingResponse(
   payload: CursorRequestPayload,
   accessToken: string,
   modelId: string,
-  bridgeKey: string,
+  convKey: string,
 ): Promise<Response> {
   const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
   const created = Math.floor(Date.now() / 1000);
-  const fullText = await collectFullResponse(payload, accessToken, bridgeKey);
+  const fullText = await collectFullResponse(payload, accessToken, convKey);
 
   return new Response(
     JSON.stringify({
@@ -1382,7 +1418,7 @@ async function handleNonStreamingResponse(
 async function collectFullResponse(
   payload: CursorRequestPayload,
   accessToken: string,
-  bridgeKey: string,
+  convKey: string,
 ): Promise<string> {
   const { promise, resolve } = Promise.withResolvers<string>();
   let fullText = "";
@@ -1415,7 +1451,7 @@ async function collectFullResponse(
           },
           () => {},
           (checkpointBytes) => {
-            const stored = conversationStates.get(bridgeKey);
+            const stored = conversationStates.get(convKey);
             if (stored) {
               stored.checkpoint = checkpointBytes;
               stored.lastAccessMs = Date.now();
@@ -1431,7 +1467,7 @@ async function collectFullResponse(
 
   bridge.onClose(() => {
     clearInterval(heartbeatTimer);
-    const stored = conversationStates.get(bridgeKey);
+    const stored = conversationStates.get(convKey);
     if (stored) {
       for (const [k, v] of payload.blobStore) stored.blobStore.set(k, v);
       stored.lastAccessMs = Date.now();


### PR DESCRIPTION
Three compounding bugs prevented non-composer models from working and caused context loss when switching models or restarting the proxy.

## Model discovery (h2-bridge.mjs)

`callCursorUnaryRpc` used streaming mode (`application/connect+proto` with Connect framing) for the `GetUsableModels` unary RPC. Cursor expects `application/proto` with a raw protobuf body for unary calls. Discovery silently failed, falling back to hardcoded models.

**Fix:** Add `unary` config flag to the H2 bridge that switches content-type and writes a single body instead of streaming.

## Fallback model IDs (models.ts)

Nearly every non-composer fallback ID was wrong: `claude-4.6-opus` (real: `claude-4.6-opus-high`), `gpt-5.4` (real: `gpt-5.4-medium`), `grok-4.20` (doesn't exist). Only `composer-2`/`composer-2-fast` happened to be valid.

**Fix:** Corrected all IDs against Oh My Pi's maintained model registry.

## Conversation context (proxy.ts)

Two issues:

1. **Context lost on model switch:** A single `bridgeKey` (model-specific) was used for both active tool-call bridges and conversation state. Switching models changed the key, creating a new `conversationId` with no history.

2. **Context lost on proxy restart:** `conversationId` was `crypto.randomUUID()` — ephemeral. After restart, the in-memory map was empty and a new random ID was generated. Cursor's server couldn't match it to the existing conversation.

**Fix:**
- Split into `bridgeKey` (model-specific, for `activeBridges`) and `convKey` (model-independent, for `conversationStates`)
- Derive `conversationId` deterministically from `convKey` hash so Cursor's server-side conversation persists across restarts

Fixes #17 