### PR TITLE
feat: expose cursor auto routing as an auto model

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -62,6 +62,18 @@ const FALLBACK_MODELS: CursorModel[] = [
   { id: "grok-code-fast-1", name: "Grok Code Fast 1", reasoning: false, contextWindow: 128_000, maxTokens: 64_000 },
 ];
 
+/**
+ * Pseudo-model for Cursor's server-side Auto routing. Always exposed
+ * alongside discovered models; the proxy maps it to Run modelId "default".
+ */
+const AUTO_MODEL: CursorModel = {
+  id: "auto",
+  name: "Auto",
+  reasoning: false,
+  contextWindow: DEFAULT_CONTEXT_WINDOW,
+  maxTokens: DEFAULT_MAX_TOKENS,
+};
+
 async function fetchCursorUsableModels(
   apiKey: string,
 ): Promise<CursorModel[] | null> {
@@ -96,7 +108,8 @@ export async function getCursorModels(
 ): Promise<CursorModel[]> {
   if (cachedModels) return cachedModels;
   const discovered = await fetchCursorUsableModels(apiKey);
-  cachedModels = discovered && discovered.length > 0 ? discovered : FALLBACK_MODELS;
+  const models = discovered && discovered.length > 0 ? discovered : FALLBACK_MODELS;
+  cachedModels = models.some((m) => m.id === AUTO_MODEL.id) ? models : [AUTO_MODEL, ...models];
   return cachedModels;
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -49,6 +49,7 @@ import {
   ReadRejectedSchema,
   ReadResultSchema,
   RequestContextResultSchema,
+  RequestedModelSchema,
   RequestContextSchema,
   RequestContextSuccessSchema,
   ResumeActionSchema,
@@ -854,16 +855,25 @@ function buildCursorRequest(
         action: { case: "resumeAction", value: create(ResumeActionSchema, {}) },
       });
 
+  // "auto" is the proxy's pseudo-model for Cursor's server-side Auto
+  // routing; the Run API expects modelId "default" for it.
+  const cursorModelId = modelId === "auto" ? "default" : modelId;
+  const displayName = modelId === "auto" ? "Auto" : modelId;
+  const requestedModel = create(RequestedModelSchema, {
+    modelId: cursorModelId,
+  });
   const modelDetails = create(ModelDetailsSchema, {
-    modelId,
-    displayModelId: modelId,
-    displayName: modelId,
+    modelId: cursorModelId,
+    displayModelId: cursorModelId,
+    displayName,
+    displayNameShort: displayName,
   });
 
   const runRequest = create(AgentRunRequestSchema, {
     conversationState,
     action,
     modelDetails,
+    requestedModel,
     conversationId,
   });
 

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -449,7 +449,7 @@ async function testExpiredTokenRefreshBeforeDiscovery(
   );
   assertArrayEqual(
     Object.keys(provider.models),
-    ["fresh-model"],
+    ["auto", "fresh-model"],
     "Expected provider models to come from successful discovery",
   );
 
@@ -508,7 +508,7 @@ async function testDiscoveryFallbackAndSuccess(
   const discoveredConfig = await hooks.auth!.loader(async () => authState, provider);
   assertArrayEqual(
     Object.keys(provider.models).sort(),
-    ["real-model-a", "real-model-b"],
+    ["auto", "real-model-a", "real-model-b"],
     "Expected successful discovery to replace fallback models",
   );
   const discoveredModelsRes = await fetch(`${discoveredConfig.baseURL}/models`);
@@ -516,7 +516,7 @@ async function testDiscoveryFallbackAndSuccess(
   const discoveredModelsBody = await discoveredModelsRes.json();
   assertArrayEqual(
     discoveredModelsBody.data.map((model: { id: string }) => model.id).sort(),
-    ["real-model-a", "real-model-b"],
+    ["auto", "real-model-a", "real-model-b"],
     "Expected proxy /v1/models to expose discovered models",
   );
 


### PR DESCRIPTION
## Summary

Reimplements the idea from #28 on top of the current proxy: expose Cursor's native Auto model selection as an `auto` model in opencode.

- `src/models.ts`: always include an `auto` pseudo-model alongside discovered (or fallback) models, deduped if the server ever returns one itself
- `src/proxy.ts`: map `auto` → Run `modelId: "default"` (display name `Auto`) so Cursor routes server-side, and set the `requestedModel` field on the Run request — matching what Cursor's own CLI sends
- `test/smoke.ts`: model-list expectations now include `auto`

Why not merge #28: its base predates the conversation-state rewrite (8b167a9) and ~2/3 of its diff was superseded by it. This is the surviving ~30-line piece.

## Verification

- `bun run build` — clean
- `bun test/smoke.ts` — all passing
- Live end-to-end: started the proxy with real Cursor auth, sent `model: "auto"` via `/v1/chat/completions`, got a 200 completion back through Cursor's Auto routing (`requestedModel`/`modelDetails` sent as `default`)