### PR TITLE
fix: handle cancelled SSE streams

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1364,10 +1364,10 @@ function createBridgeStreamResponse(
   const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
   const created = Math.floor(Date.now() / 1000);
 
+  let closed = false;
   const stream = new ReadableStream({
     start(controller) {
       const encoder = new TextEncoder();
-      let closed = false;
       const sendSSE = (data: object) => {
         if (closed) return;
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
@@ -1541,6 +1541,9 @@ function createBridgeStreamResponse(
           activeBridges.delete(bridgeKey);
         }
       });
+    },
+    cancel() {
+      closed = true;
     },
   });
 


### PR DESCRIPTION
This fixes an issue I had using the plugin, have been getting this error:
```typescript
1007 |             const encoder = new TextEncoder();
1008 |             let closed = false;
1009 |             const sendSSE = (data) => {
1010 |                 if (closed)
1011 |                     return;
1012 |                 controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
                 ^
TypeError: Invalid state: Controller is already closed
 code: "ERR_INVALID_STATE"

      at sendSSE (/home/noam/.cache/opencode/packages/opencode-cursor-oauth@latest/node_modules/opencode-cursor-oauth/dist/proxy.js:1012:28)
      at <anonymous> (/home/noam/.cache/opencode/packages/opencode-cursor-oauth@latest/node_modules/opencode-cursor-oauth/dist/proxy.js:1150:21)
      at <anonymous> (/home/noam/.cache/opencode/packages/opencode-cursor-oauth@latest/node_modules/opencode-cursor-oauth/dist/proxy.js:173:13)
```

I used an LLM to fix the issue. While I am not very familiar with typescript, the fix looks reasonable to me, and the issue did not persist after making the change.